### PR TITLE
fixed 1.8 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = '_1ms'
-version = '1.5.5'
+version = '1.5.6'
 
 repositories {
     mavenCentral()

--- a/src/main/java/_1ms/playtimelink/RequestSender.java
+++ b/src/main/java/_1ms/playtimelink/RequestSender.java
@@ -95,7 +95,7 @@ public class RequestSender implements PluginMessageListener {
             }
             case "rs" -> {//restart(proxy restarted)
                 sendReq("cc"); //confirm
-                if(PtTask != null && PtTask.isCancelled()) {
+                if(PtTask != null && !Bukkit.getScheduler().isCurrentlyRunning(PtTask.getTaskId())) {
                     runPlaytimeUpdates();
                     if(!pttop.isEmpty())
                         startGetTL();


### PR DESCRIPTION
Fixes `java.lang.NoSuchMethodError` in 1.8 servers:

```
[17:57:30 WARN]: Could not pass incoming plugin message to PlaytimeLink v1.5.0
java.lang.NoSuchMethodError: 'boolean org.bukkit.scheduler.BukkitTask.isCancelled()'
	at _1ms.playtimelink.RequestSender.onPluginMessageReceived(RequestSender.java:97) ~[?:?]
	at org.bukkit.plugin.messaging.StandardMessenger.dispatchIncomingMessage(StandardMessenger.java:429) ~[patched_1.8.8.jar:git-PandaSpigot-122]
	at net.minecraft.server.v1_8_R3.PlayerConnection.a(PlayerConnection.java:2274) ~[patched_1.8.8.jar:git-PandaSpigot-122]
	at net.minecraft.server.v1_8_R3.PacketPlayInCustomPayload.a(PacketPlayInCustomPayload.java:30) ~[patched_1.8.8.jar:git-PandaSpigot-122]
	at net.minecraft.server.v1_8_R3.PacketPlayInCustomPayload.a(PacketPlayInCustomPayload.java:6) ~[patched_1.8.8.jar:git-PandaSpigot-122]
	at net.minecraft.server.v1_8_R3.PlayerConnectionUtils$1.run(PlayerConnectionUtils.java:9) ~[patched_1.8.8.jar:git-PandaSpigot-122]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
	at net.minecraft.server.v1_8_R3.SystemUtils.a(SystemUtils.java:11) ~[patched_1.8.8.jar:git-PandaSpigot-122]
	at net.minecraft.server.v1_8_R3.MinecraftServer.B(MinecraftServer.java:881) ~[patched_1.8.8.jar:git-PandaSpigot-122]
	at net.minecraft.server.v1_8_R3.DedicatedServer.B(DedicatedServer.java:412) ~[patched_1.8.8.jar:git-PandaSpigot-122]
	at net.minecraft.server.v1_8_R3.MinecraftServer.A(MinecraftServer.java:815) ~[patched_1.8.8.jar:git-PandaSpigot-122]
	at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:648) ~[patched_1.8.8.jar:git-PandaSpigot-122]
	at net.minecraft.server.v1_8_R3.MinecraftServer.lambda$spin$0(MinecraftServer.java:133) ~[patched_1.8.8.jar:git-PandaSpigot-122]
	at java.lang.Thread.run(Thread.java:1583) [?:?]

```

Uses `BukkitScheduler.isCurrentlyRunning(taskid)` instead of `BukkitTask.isCancelled()`.